### PR TITLE
add CZI grant: written on github, licensed CC-BY

### DIFF
--- a/_authors/greene_casey.md
+++ b/_authors/greene_casey.md
@@ -1,0 +1,7 @@
+---
+name: Casey S. Greene
+ORCID: 0000-0001-8713-9213
+institution: University of Pennsylvania
+website: http://www.greenelab.com
+twitter: greenescientist
+---

--- a/_grants/greene_casey_2017
+++ b/_grants/greene_casey_2017
@@ -1,0 +1,12 @@
+---
+layout: grant
+title: Genome-wide hypothesis generation for single-cell expression via latent spaces of deep neural networks
+author: Casey S. Greene
+ORCID: 0000-0001-8713-9213
+year: 2017
+link: https://github.com/greenelab/czi-rfa/blob/master/proposal.md
+funder: Chan Zuckerberg Initiative
+program: Collaborative Computational Tools for the Human Cell Atlas
+discipline: genomics
+status: TBD
+---


### PR DESCRIPTION
This adds a grant that I wrote with members of my lab for a recent CZI RFA. It was written on github, along with a number of proposals within our collaborative network. This makes it possible to see not just the final form but the progress along the way.