### PR TITLE
remove double slash in niaid.nih.gov//sites

### DIFF
--- a/_grants/ambroggio_lilliam_2016.md
+++ b/_grants/ambroggio_lilliam_2016.md
@@ -3,8 +3,8 @@ author: Lilliam Ambroggio
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/K01-Lilliam-Ambroggio-Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/K01-Lilliam-Ambroggio-Summary-Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/K01-Lilliam-Ambroggio-Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/K01-Lilliam-Ambroggio-Summary-Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/brooks_benjamin_2016.md
+++ b/_grants/brooks_benjamin_2016.md
@@ -3,8 +3,8 @@ author: Benjamin Delbert Brooks
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/R43-Brooks-Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/R43-Brooks-Summary-Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/R43-Brooks-Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/R43-Brooks-Summary-Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/coleman_kenneth_2014.md
+++ b/_grants/coleman_kenneth_2014.md
@@ -2,7 +2,7 @@
 author: Kenneth Coleman
 funder: National Institutes of Health (US)
 layout: grant
-link: https://www.niaid.nih.gov//sites/default/files/1r44ai112187-01a1_coleman.pdf
+link: https://www.niaid.nih.gov/sites/default/files/1r44ai112187-01a1_coleman.pdf
 link_name: Proposal
 program: R41, R42, R43, R44
 status: funded

--- a/_grants/dewhurst_stephen_2010.md
+++ b/_grants/dewhurst_stephen_2010.md
@@ -3,8 +3,8 @@ author: Stephen Dewhurst
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/dewhurstfull.pdf
-- https://www.niaid.nih.gov//sites/default/files/dewhurstss.pdf
+- https://www.niaid.nih.gov/sites/default/files/dewhurstfull.pdf
+- https://www.niaid.nih.gov/sites/default/files/dewhurstss.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/domashevskiy_artem_2016.md
+++ b/_grants/domashevskiy_artem_2016.md
@@ -3,8 +3,8 @@ author: Artem Domashevskiy
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/R15-Artem-Domashevskiy-Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/R15-Artem-Domashevskiy-Summary-Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/R15-Artem-Domashevskiy-Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/R15-Artem-Domashevskiy-Summary-Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/dow_steven_2010.md
+++ b/_grants/dow_steven_2010.md
@@ -3,8 +3,8 @@ author: Steven W. Dow
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/dowfull.pdf
-- https://www.niaid.nih.gov//sites/default/files/dowss.pdf
+- https://www.niaid.nih.gov/sites/default/files/dowfull.pdf
+- https://www.niaid.nih.gov/sites/default/files/dowss.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/faubion_william_2015.md
+++ b/_grants/faubion_william_2015.md
@@ -3,8 +3,8 @@ author: William Faubion
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/R01-Faubion-app.pdf
-- https://www.niaid.nih.gov//sites/default/files/R01-Faubion-sum.pdf
+- https://www.niaid.nih.gov/sites/default/files/R01-Faubion-app.pdf
+- https://www.niaid.nih.gov/sites/default/files/R01-Faubion-sum.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/fong_timothy_2013.md
+++ b/_grants/fong_timothy_2013.md
@@ -2,7 +2,7 @@
 author: Timothy C. Fong
 funder: National Institutes of Health (US)
 layout: grant
-link: https://www.niaid.nih.gov//sites/default/files/1r41ai10801601_fong_0.pdf
+link: https://www.niaid.nih.gov/sites/default/files/1r41ai10801601_fong_0.pdf
 link_name: Proposal
 program: R41, R42, R43, R44
 status: funded

--- a/_grants/galarza_jose_2013.md
+++ b/_grants/galarza_jose_2013.md
@@ -2,7 +2,7 @@
 author: Jose M. Galarza
 funder: National Institutes of Health (US)
 layout: grant
-link: https://www.niaid.nih.gov//sites/default/files/1r43ai106145-01a1_galarza.pdf
+link: https://www.niaid.nih.gov/sites/default/files/1r43ai106145-01a1_galarza.pdf
 link_name: Proposal
 program: R41, R42, R43, R44
 status: funded

--- a/_grants/gandhi_monica_2017.md
+++ b/_grants/gandhi_monica_2017.md
@@ -3,8 +3,8 @@ author: Monica Gandhi
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/2-R01-AI098472-06_Gandhi_Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/2-R01-AI098472-06_Ganhdi_Summary.pdf
+- https://www.niaid.nih.gov/sites/default/files/2-R01-AI098472-06_Gandhi_Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/2-R01-AI098472-06_Ganhdi_Summary.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/garrett_patricia_2014.md
+++ b/_grants/garrett_patricia_2014.md
@@ -2,7 +2,7 @@
 author: Patricia Garrett
 funder: National Institutes of Health (US)
 layout: grant
-link: https://www.niaid.nih.gov//sites/default/files/2r44ai098567-03_garrett.pdf
+link: https://www.niaid.nih.gov/sites/default/files/2r44ai098567-03_garrett.pdf
 link_name: Proposal
 program: R41, R42, R43, R44
 status: funded

--- a/_grants/gordon_vernita_2017.md
+++ b/_grants/gordon_vernita_2017.md
@@ -3,8 +3,8 @@ author: Vernita Gordon
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/1-R01-AI121500-01A1_Gordon_Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/1-R01-AI121500-01A1_Gordon_Summary-Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/1-R01-AI121500-01A1_Gordon_Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/1-R01-AI121500-01A1_Gordon_Summary-Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/houghton_raymond_2014.md
+++ b/_grants/houghton_raymond_2014.md
@@ -2,7 +2,7 @@
 author: Raymond Houghton
 funder: National Institutes of Health (US)
 layout: grant
-link: https://www.niaid.nih.gov//sites/default/files/2r42ai102482-03_houghton.pdf
+link: https://www.niaid.nih.gov/sites/default/files/2r42ai102482-03_houghton.pdf
 link_name: Proposal
 program: R41, R42, R43, R44
 status: funded

--- a/_grants/jiang_mengxi_2015.md
+++ b/_grants/jiang_mengxi_2015.md
@@ -3,8 +3,8 @@ author: Mengxi Jiang
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/R01_Jiang_Sample_Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/R01_Jiang_Sample_Summary_Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/R01_Jiang_Sample_Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/R01_Jiang_Sample_Summary_Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/karplus_martin_2014.md
+++ b/_grants/karplus_martin_2014.md
@@ -3,7 +3,7 @@ author: Martin Karplus
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/1r03ai111416-01_karplus_sample_app.pdf
+- https://www.niaid.nih.gov/sites/default/files/1r03ai111416-01_karplus_sample_app.pdf
 link_name:
 - Proposal
 program: R03

--- a/_grants/li_chengwen_2015.md
+++ b/_grants/li_chengwen_2015.md
@@ -3,8 +3,8 @@ author: Chengwen Li
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/R01_Li_Sample_Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/R01_Li_Summary_Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/R01_Li_Sample_Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/R01_Li_Summary_Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/liu_yingru_2016.md
+++ b/_grants/liu_yingru_2016.md
@@ -3,8 +3,8 @@ author: Yingru Liu
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/R44-Liu-Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/R44-Liu-Summary-Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/R44-Liu-Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/R44-Liu-Summary-Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/lochhead_michael_2013.md
+++ b/_grants/lochhead_michael_2013.md
@@ -2,7 +2,7 @@
 author: Michael J. Lochhead
 funder: National Institutes of Health (US)
 layout: grant
-link: https://www.niaid.nih.gov//sites/default/files/2r44ai093289-02a1_lochhead_0.pdf
+link: https://www.niaid.nih.gov/sites/default/files/2r44ai093289-02a1_lochhead_0.pdf
 link_name: Proposal
 program: R41, R42, R43, R44
 status: funded

--- a/_grants/lu_lenette_2016.md
+++ b/_grants/lu_lenette_2016.md
@@ -3,8 +3,8 @@ author: Lenette Lu
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/K08-Lenette-Lu-Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/K08-Lenette-Lu-Summary-Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/K08-Lenette-Lu-Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/K08-Lenette-Lu-Summary-Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/mccune_joseph_2010.md
+++ b/_grants/mccune_joseph_2010.md
@@ -3,8 +3,8 @@ author: Joseph M. McCune
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/mccunefull.pdf
-- https://www.niaid.nih.gov//sites/default/files/mccuness.pdf
+- https://www.niaid.nih.gov/sites/default/files/mccunefull.pdf
+- https://www.niaid.nih.gov/sites/default/files/mccuness.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/myler_peter_2010.md
+++ b/_grants/myler_peter_2010.md
@@ -3,8 +3,8 @@ author: Peter John Myler
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/mylerparsonsfull.pdf
-- https://www.niaid.nih.gov//sites/default/files/mylerparsonsss.pdf
+- https://www.niaid.nih.gov/sites/default/files/mylerparsonsfull.pdf
+- https://www.niaid.nih.gov/sites/default/files/mylerparsonsss.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/petrie_howard_2011.md
+++ b/_grants/petrie_howard_2011.md
@@ -3,8 +3,8 @@ author: Howard T. Petrie
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/petriefull.pdf
-- https://www.niaid.nih.gov//sites/default/files/petriess.pdf
+- https://www.niaid.nih.gov/sites/default/files/petriefull.pdf
+- https://www.niaid.nih.gov/sites/default/files/petriess.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/rappleye_chad_2013.md
+++ b/_grants/rappleye_chad_2013.md
@@ -3,8 +3,8 @@ author: Chad A. Rappleye
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/1r03ai111015-01_rappleye_full.pdf
-- https://www.niaid.nih.gov//sites/default/files/1r03ai111015-01_rappleye_ss.pdf
+- https://www.niaid.nih.gov/sites/default/files/1r03ai111015-01_rappleye_full.pdf
+- https://www.niaid.nih.gov/sites/default/files/1r03ai111015-01_rappleye_ss.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/smith_james_2016.md
+++ b/_grants/smith_james_2016.md
@@ -3,8 +3,8 @@ author: James Smith
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/R41-Smith-Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/R41-Smith-Summary-Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/R41-Smith-Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/R41-Smith-Summary-Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/starnbach_michael_2011.md
+++ b/_grants/starnbach_michael_2011.md
@@ -3,8 +3,8 @@ author: Michael N. Starnbach
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/starnbachfull.pdf
-- https://www.niaid.nih.gov//sites/default/files/starnbachss.pdf
+- https://www.niaid.nih.gov/sites/default/files/starnbachfull.pdf
+- https://www.niaid.nih.gov/sites/default/files/starnbachss.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/tran_tuan_2016.md
+++ b/_grants/tran_tuan_2016.md
@@ -3,8 +3,8 @@ author: Tuan Manh Tran
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/K08-Tuan-Manh-Tran-Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/K08-Tuan-Manh-Tran-Summary-Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/K08-Tuan-Manh-Tran-Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/K08-Tuan-Manh-Tran-Summary-Statement.pdf
 link_name:
 - Proposal
 - Summary Statement

--- a/_grants/wagner_david_2016.md
+++ b/_grants/wagner_david_2016.md
@@ -3,8 +3,8 @@ author: David H. Wagner
 funder: National Institutes of Health (US)
 layout: grant
 link:
-- https://www.niaid.nih.gov//sites/default/files/R41-Wagner-Application.pdf
-- https://www.niaid.nih.gov//sites/default/files/R41-Wagner-Summary-Statement.pdf
+- https://www.niaid.nih.gov/sites/default/files/R41-Wagner-Application.pdf
+- https://www.niaid.nih.gov/sites/default/files/R41-Wagner-Summary-Statement.pdf
 link_name:
 - Proposal
 - Summary Statement


### PR DESCRIPTION
I think the test failures in https://travis-ci.org/weecology/ogrants/builds/594579514 were just the result of  temporary downtime at https://www.niaid.nih.gov, and not related to the changes in this PR. But thought we might as well clean up these URLs.