### PR TITLE
Standardize U.S. NSF usage

### DIFF
--- a/_grants/baecher_joseph_2023.md
+++ b/_grants/baecher_joseph_2023.md
@@ -6,7 +6,7 @@ ORCID: 0000-0003-0247-5758
 year: '2023'
 institution: University of Florida
 link: https://www.ogrants.org/proposals/baecher_joseph_2023.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Fellowship in Biology
 discipline: ecology
 status: unknown

--- a/_grants/bahlai_christie_2021.md
+++ b/_grants/bahlai_christie_2021.md
@@ -5,7 +5,7 @@ author: Christie Bahlai
 ORCID: 0000-0001-6933-5253
 year: 2021
 link: https://github.com/BahlaiLab/CAREER2020
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: CAREER
 discipline: ecology, informatics
 status: funded

--- a/_grants/barkdull_megan_2021.md
+++ b/_grants/barkdull_megan_2021.md
@@ -6,7 +6,7 @@ ORCID: ""
 year: 2021
 link: ["https://zenodo.org/record/4906357#.YL4qSC1h2u4"]
 link_name: ["Proposal"]
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: evolution
 status: funded

--- a/_grants/bertolet_brittnil_2021.md
+++ b/_grants/bertolet_brittnil_2021.md
@@ -5,7 +5,7 @@ author: Brittni L. Bertolet
 year: '2021'
 institution: University of California Irvine
 link: https://www.ogrants.org/proposals/bertolet_brittnil_2021.pdf
-funder: National Science Foundation
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Research Fellowship in Biology
 discipline: microbial ecology and biogeochemistry
 status: funded

--- a/_grants/bhaskar_aditi_2013.md
+++ b/_grants/bhaskar_aditi_2013.md
@@ -6,7 +6,7 @@ ORCID: "0000-0001-9803-4003"
 year: 2013
 link: ["https://353a23c500dde3b2ad58-c49fe7e7355d384845270f4a7a0a7aa1.ssl.cf2.rackcdn.com/a2643c8b-fbfb-414b-818e-88cdd3233a6d/Aditi%20NSF-EAR-PF%20project%20summary%20description%20and%20references.pdf"]
 link_name: ["Proposal"]
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: EAR Postdoctoral Fellowship
 discipline: arth sciences
 status: funded

--- a/_grants/bird_kevin_2016.md
+++ b/_grants/bird_kevin_2016.md
@@ -6,7 +6,7 @@ ORCID: 0000-0002-3174-3646
 year: 2016
 link: ['https://github.com/ybrandvain/GRFP/blob/master/Bird_NSF_Research_official.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/BirdNSFPersonal_official.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/BirdNSFreview.pdf']
 link_name: ['Research Statement', 'Personal Statement', 'Reviews']
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: Genomics
 status: funded

--- a/_grants/brown_ctitus_2011.md
+++ b/_grants/brown_ctitus_2011.md
@@ -4,7 +4,7 @@ title: 'CAREER: Scaling and Improving de Bruijn graph assembly'
 author: C. Titus Brown
 year: 2011
 link: https://github.com/dib-lab/www-ged.msu.edu/blob/master/downloads/2011-nsf-career.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: CAREER
 status: unfunded
 ---

--- a/_grants/brown_ctitus_2012b.md
+++ b/_grants/brown_ctitus_2012b.md
@@ -4,7 +4,7 @@ title: Materials and Workshops for Cyberinfrastructure Education in Biology
 author: C. Titus Brown
 year: 2012
 link: https://github.com/dib-lab/www-ged.msu.edu/blob/master/downloads/2012-beacon-education-suppl-pub.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Cyberinfrastructure
 status: funded
 ---

--- a/_grants/brown_ctitus_2012c.md
+++ b/_grants/brown_ctitus_2012c.md
@@ -4,7 +4,7 @@ title: 'CAREER: Assembling Extremely Large Metagenomes'
 author: C. Titus Brown
 year: 2012
 link: https://github.com/dib-lab/www-ged.msu.edu/blob/master/downloads/2012-career-nsf-final.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: CAREER
 status: unfunded
 ---

--- a/_grants/brown_ctitus_2012d.md
+++ b/_grants/brown_ctitus_2012d.md
@@ -4,7 +4,7 @@ title: Low-memory Streaming Prefilters for Biological Sequencing Data
 author: C. Titus Brown
 year: 2012
 link: https://github.com/dib-lab/www-ged.msu.edu/blob/master/downloads/2012-bigdata-nsf.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: BIGDATA
 status: funded
 ---

--- a/_grants/burgio_kevin_2010.md
+++ b/_grants/burgio_kevin_2010.md
@@ -5,7 +5,7 @@ author: Kevin R. Burgio
 ORCID: 0000-0002-8375-2501
 year: 2010
 link: https://doi.org/10.6084/m9.figshare.5215894
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: ecology and physiology
 status: funded

--- a/_grants/chamberlain_scott_unknowne.md
+++ b/_grants/chamberlain_scott_unknowne.md
@@ -3,7 +3,7 @@ layout: grant
 title: Mechanisms for the Structure of Sonoran Desert Ant-Plant Mutualistic Communities
 author: Scott Chamberlain
 link: https://doi.org/10.6084/m9.figshare.94219
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: DDIG
 status: unfunded
 ---

--- a/_grants/chan_joel_2014.md
+++ b/_grants/chan_joel_2014.md
@@ -6,7 +6,7 @@ ORCID:
 year: 2014
 link: ['https://353a23c500dde3b2ad58-c49fe7e7355d384845270f4a7a0a7aa1.ssl.cf2.rackcdn.com/76553f9b-017b-4023-adcc-c870353dc25a/Chan_DissertationImprovementGrant.pdf']
 link_name: ['Proposal']
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Dissertation Improvement Grant (DDIG)
 discipline: psychology
 status: funded

--- a/_grants/clark_adam_2011.md
+++ b/_grants/clark_adam_2011.md
@@ -6,7 +6,7 @@ ORCID:
 year: 2011
 link: ['https://github.com/ybrandvain/GRFP/blob/master/Ddrabeck_GRFP_ResearchPlan_2013.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/Ddrabeck_GRFP_PersonalStatement_2013.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/Ddrabeck_GRFP_Previous%20Experience_2013.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/Ddrabeck_GRFP_Review_2013.pdf']
 link_name: ['Research Statement', 'Personal Statement', 'Previous Experience', 'Reviews']
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: Ecology
 status: funded

--- a/_grants/cranston_karen_2011.md
+++ b/_grants/cranston_karen_2011.md
@@ -4,7 +4,7 @@ title: Automated and community synthesis of the tree of life
 author: Karen Cranston
 year: 2011
 link: http://opentree.wikispaces.com/Grant+Proposal
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: AVATOL
 status: funded
 ---

--- a/_grants/dasari_mauna_2021.md
+++ b/_grants/dasari_mauna_2021.md
@@ -7,7 +7,7 @@ ORCID: https://orcid.org/0000-0002-1956-2500
 year: '2021'
 institution: University of Pittsburgh
 link: https://www.ogrants.org/proposals/dasari_mauna_2021.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: 'Postdoctoral Research Fellowship in Biology (Area: Rules of Life)'
 discipline: ecology
 status: funded

--- a/_grants/dawe_kelly_2009.md
+++ b/_grants/dawe_kelly_2009.md
@@ -4,7 +4,7 @@ title: Functional Genomics of Maize Centromeres
 author: Kelly Dawe, Jeff Ross-Ibarra, James Birchler, Jiming Jiang, Wayne Parrott, Gernot Presting
 year: 2009
 link: https://github.com/RILAB/statements/blob/master/grants/Dawe_NSF_PlantGenome_2009.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Plant Genome
 status: funded
 ---

--- a/_grants/diaz_renata_2016.md
+++ b/_grants/diaz_renata_2016.md
@@ -6,7 +6,7 @@ author: Renata M. Diaz
 ORCID:  0000-0003-0803-4734 
 year: 2016
 link: https://doi.org/10.6084/m9.figshare.5362636
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: GRFP
 discipline: ecology
 status: funded

--- a/_grants/dlugosch_katrina_2017.md
+++ b/_grants/dlugosch_katrina_2017.md
@@ -6,7 +6,7 @@ ORCID: 0000-0002-7302-6637
 year: 2017
 link: ["https://353a23c500dde3b2ad58-c49fe7e7355d384845270f4a7a0a7aa1.ssl.cf2.rackcdn.com/5762118d-2456-4129-9811-f236ddf5c925/Dlugosch_CAREER_2017_SummaryDescription.pdf"]
 link_name: ["Proposal"]
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: CAREER
 discipline: "ecology, evolution, plant science"
 status: funded

--- a/_grants/drabeck_danielle_2013.md
+++ b/_grants/drabeck_danielle_2013.md
@@ -6,7 +6,7 @@ ORCID:
 year: 2013
 link: ['https://github.com/ybrandvain/GRFP/blob/master/Ddrabeck_GRFP_ResearchPlan_2013.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/Ddrabeck_GRFP_PersonalStatement_2013.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/Ddrabeck_GRFP_Previous%20Experience_2013.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/Ddrabeck_GRFP_Review_2013.pdf']
 link_name: ['Research Statement', 'Personal Statement', 'Previous Experience', 'Reviews']
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: Evolution
 status: unfunded

--- a/_grants/durvasula_arun_2018.md
+++ b/_grants/durvasula_arun_2018.md
@@ -6,7 +6,7 @@ ORCID: 0000-0003-0631-3238
 year: 2018
 link: ['https://github.com/ybrandvain/GRFP/blob/master/Arun_Durvasula_Research_Proposal_2018.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/Arun_Durvasula_Personal_Statement_2018.pdf', 'https://github.com/ybrandvain/GRFP/blob/master/Arun_Durvasula_NSF_reviews.pdf']
 link_name: ['Research Statement', 'Personal Statement', 'Reviews']
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: Genomics
 status: funded

--- a/_grants/ernest_morgan_2013.md
+++ b/_grants/ernest_morgan_2013.md
@@ -4,7 +4,7 @@ title: Reversing long-term experiments to understand regime shifts
 author: Morgan Ernest
 year: 2013
 link: https://ndownloader.figshare.com/files/1694745
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Population & Community Ecology
 status: funded
 ---

--- a/_grants/evans_michelle_2014.md
+++ b/_grants/evans_michelle_2014.md
@@ -5,7 +5,7 @@ author: Michelle V. Evans
 ORCID: 0000-0002-5628-0502
 year: 2014
 link: https://doi.org/10.6084/m9.figshare.5217382
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: biological sciences
 status: not funded

--- a/_grants/evans_michelle_2015.md
+++ b/_grants/evans_michelle_2015.md
@@ -5,7 +5,7 @@ author: Michelle V. Evans
 ORCID: 0000-0002-5628-0502
 year: 2015
 link: https://doi.org/10.6084/m9.figshare.5217373
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: biological sciences
 status: funded

--- a/_grants/fan_jean_2013.md
+++ b/_grants/fan_jean_2013.md
@@ -5,7 +5,7 @@ author: Jean Fan
 ORCID: 0000-0002-0212-5451
 year: 2013
 link: https://jef.works/blog/2017/10/15/NSF-GRFP-application-tips-and-example/
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: bioinformatics
 status: funded

--- a/_grants/flores_alejandro_2014.md
+++ b/_grants/flores_alejandro_2014.md
@@ -1,7 +1,7 @@
 ---
 author: Alejandro N. Flores
 ORCID: 0000-0002-7240-9265
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 layout: grant
 link: "https://doi.org/10.5281/zenodo.3236624"
 program: CAREER

--- a/_grants/fournier_auriel_2015c.md
+++ b/_grants/fournier_auriel_2015c.md
@@ -5,7 +5,7 @@ author: Auriel M.V. Fournier
 ORCID: 0000-0002-8530-9968
 year: 2015
 link: https://doi.org/10.6084/m9.figshare.5216020.v1
-funder:  NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: EAPSI
 discipline: ecology
 status: unfunded

--- a/_grants/franz_nico_2016.md
+++ b/_grants/franz_nico_2016.md
@@ -4,7 +4,7 @@ title: 'Controlling the taxonomic variable: Taxonomic concept resolution for a s
 author: Nico Franz
 year: 2016
 link: https://doi.org/10.3897/rio.2.e10610
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Advances in Biological Informatics (ABI)
 status:
 ---

--- a/_grants/hamlington_peter_2019.md
+++ b/_grants/hamlington_peter_2019.md
@@ -6,7 +6,7 @@ ORCID: 0000-0003-4425-7097
 year: 2019
 link: ["https://doi.org/10.5281/zenodo.3460972"]
 link_name: ["Proposal"]
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Division of Ocean Sciences
 discipline: oceanography
 status: funded

--- a/_grants/harte_ted_2008.md
+++ b/_grants/harte_ted_2008.md
@@ -4,7 +4,7 @@ title: Evolution under simulated climate change in response to trophic shifts
 author: Ted Harte
 year: 2008
 link: https://doi.org/10.6084/m9.figshare.95607
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Dissertation Improvement Grant (DDIG)
 status: funded
 ---

--- a/_grants/hatala_kevin_2012b.md
+++ b/_grants/hatala_kevin_2012b.md
@@ -7,7 +7,7 @@ year: 2012
 link: ['
 https://figshare.com/articles/NSF_DDIG_Fossil_footprints_and_the_dynamics_of_footprint_formation_Implications_for_the_evolution_of_human_gait_2012_/7958738']
 link_name: ['Proposal']
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Dissertation Improvement Grant (DDIG)
 discipline: biological anthropology
 status: funded

--- a/_grants/hatala_kevin_2014.md
+++ b/_grants/hatala_kevin_2014.md
@@ -6,7 +6,7 @@ ORCID: 0000-0001-9131-5304
 year: 2014
 link: ['https://figshare.com/articles/NSF_SBE_Interdisciplinary_Postdoctoral_Fellowship_Computer_Science_meets_Anthropology_a_novel_approach_for_reconstructing_locomotion_from_fossil_human_footprints_2014_/7958927']
 link_name: ['Proposal']
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: SBE Office of Multidisciplinary Activities (SMA)
 discipline: biological anthropology
 status: funded

--- a/_grants/hayes_katherine_2022.md
+++ b/_grants/hayes_katherine_2022.md
@@ -7,7 +7,7 @@ ORCID: 0000-0002-6612-9398
 year: '2022'
 institution: Cary Institute of Ecosystem Studies
 link: https://www.nsf.gov/awardsearch/showAward?AWD_ID=2219248&HistoricalAwards=false
-funder: National Science Foundation
+funder: "U.S. National Science Foundation (NSF)"
 program: Office of Polar Programs
 discipline: Ecology
 status: funded

--- a/_grants/jensen_jan_2002.md
+++ b/_grants/jensen_jan_2002.md
@@ -4,7 +4,7 @@ title: The Prediction and Interpretation of Protein pKa’s Using QM/MM
 author: Jan Jensen
 year: 2002
 link: https://doi.org/10.6084/m9.figshare.91249.v1
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: MCB
 status: funded
 ---

--- a/_grants/jensen_jan_2006c.md
+++ b/_grants/jensen_jan_2006c.md
@@ -4,7 +4,7 @@ title: 'Prediction and Interpretation of Protein pKa’s Using QM/MM'
 author: Jan Jensen
 year: 2006
 link: https://doi.org/10.6084/m9.figshare.91308.v1
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: MCB
 status: funded
 ---

--- a/_grants/johnson_lisa_2016.md
+++ b/_grants/johnson_lisa_2016.md
@@ -5,7 +5,7 @@ author: Lisa K. Johnson
 ORCID: 0000-0002-3600-7218
 year: 2016
 link: https://doi.org/10.6084/m9.figshare.6913616.v1
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: Life Sciences - Environmental Biology
 status: not funded - honorable mention

--- a/_grants/johnson_milo_2016.md
+++ b/_grants/johnson_milo_2016.md
@@ -6,7 +6,7 @@ ORCID:
 year: 2016
 link: ["https://doi.org/10.5281/zenodo.4025486"]
 link_name: ["Proposal"]
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: Evolutionary Biology
 status: funded

--- a/_grants/kenyon-flatt_brittany_2020.md
+++ b/_grants/kenyon-flatt_brittany_2020.md
@@ -6,7 +6,7 @@ ORCID: ""
 year: 2020
 link: ["https://figshare.com/articles/online_resource/Kenyon-Flatt_NSF_DDRIG_2020_pdf/12896696"]
 link_name: ["Proposal"]
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: DDRIG
 discipline: 
 status: funded

--- a/_grants/kenyon-flatt_brittany_2020b.md
+++ b/_grants/kenyon-flatt_brittany_2020b.md
@@ -6,7 +6,7 @@ ORCID: ""
 year: 2020
 link: ["https://figshare.com/articles/online_resource/Kenyon-Flatt_NSF_PRFB_2020/12896738"]
 link_name: ["Proposal"]
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Fellowship in Biology
 discipline: 
 status: funded

--- a/_grants/klein_arno_2016f.md
+++ b/_grants/klein_arno_2016f.md
@@ -4,7 +4,7 @@ title: 'Data-Visual Relationships to Subject Performance and Eye Movements'
 author: Arno Klein
 year: 2016
 link: https://doi.org/10.3897/rio.2.e8814
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: PD 03-7252 (1/15/2007) BCS - PERCEPTION, ACTION & COGNITION
 status: unfunded
 ---

--- a/_grants/lapp_2010.md
+++ b/_grants/lapp_2010.md
@@ -4,7 +4,7 @@ title: Towards a comprehensive, community-owned and sustainable repository of re
 author: Hilmar Lapp, William Piel, Michael Donoghue, Mark Westneat, Matt Bietz, Karen Cranston, David Maddison
 year: 2010
 link: http://www.evoio.org/wiki/ABI_2011_proposal
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: ABI
 status: unfunded
 ---

--- a/_grants/ling_emi_2010a.md
+++ b/_grants/ling_emi_2010a.md
@@ -6,7 +6,7 @@ ORCID: 0000-0001-5287-0284
 year: 2010
 link: [https://doi.org/10.5281/zenodo.10278378]
 link_name: [Application]
-funder: "NSF"
+funder: "U.S. National Science Foundation (NSF)"
 program: "Graduate Research Fellowship Program"
 status: funded
 ---

--- a/_grants/lurie_daniel_2013.md
+++ b/_grants/lurie_daniel_2013.md
@@ -5,7 +5,7 @@ author: Daniel J. Lurie
 ORCID: 0000-0001-8012-6399
 year: 2013
 link: https://doi.org/10.6084/m9.figshare.6885278
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: cognitive neuroscience
 status: funded

--- a/_grants/moritz_mark_1999.md
+++ b/_grants/moritz_mark_1999.md
@@ -5,7 +5,7 @@ author: Mark Moritz
 ORCID: 0000-0003-0644-0069
 year: 1999
 link: https://mlab.osu.edu/sites/mlab.osu.edu/files/NSF%20DDIG%20proposal%20Mark%20Moritz%201999.PDF
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Cultural Anthropology
 discipline: anthropology
 status: funded

--- a/_grants/moritz_mark_2008.md
+++ b/_grants/moritz_mark_2008.md
@@ -5,7 +5,7 @@ author: Mark Moritz
 ORCID: 0000-0003-0644-0069
 year: 2008
 link: https://mlab.osu.edu/sites/mlab.osu.edu/files/NSF%20CAREER%20description%20-%20Mark%20Moritz.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: CAREER
 discipline: anthropology
 status: funded

--- a/_grants/moritz_mark_2009.md
+++ b/_grants/moritz_mark_2009.md
@@ -5,7 +5,7 @@ author: 'Rebecca Garabed (PI), Song Liang, Mark Moritz, and Ningshuan Xiao'
 ORCID: 
 year: 2009
 link: https://mlab.osu.edu/sites/mlab.osu.edu/files/EEID%20project%20description%202009.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Ecology and Evolution of Infectious Diseases (EEID) 
 discipline: interdisciplinary, veterinary medicine, geography, public health, anthropology
 status: funded

--- a/_grants/moritz_mark_2012.md
+++ b/_grants/moritz_mark_2012.md
@@ -5,7 +5,7 @@ author: Mark Moritz, Michael Durand, Ian Hamilton, Bryan Mark, Ningchuan Xiao
 ORCID: 0000-0003-0644-0069
 year: 2012
 link: https://mlab.osu.edu/sites/mlab.osu.edu/files/project%20description%20CNH%20MORSL.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Dynamics of Coupled Human and Natural Systems
 discipline: anthropology, geography, earth sciences, ecology, biology, environmental sciences
 status: funded

--- a/_grants/moritz_mark_2015.md
+++ b/_grants/moritz_mark_2015.md
@@ -5,7 +5,7 @@ author: Mark Moritz
 ORCID: 0000-0003-0644-0069
 year: 2015
 link: https://mlab.osu.edu/sites/mlab.osu.edu/files/RAPID%20proposal%20-%20Mark%20Moritz.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Cultural Anthropology
 discipline: anthropology
 status: funded

--- a/_grants/nell_lucas_2022.md
+++ b/_grants/nell_lucas_2022.md
@@ -7,7 +7,7 @@ ORCID: 0000-0003-3209-0517
 year: '2022'
 institution: Stanford University
 link: https://www.ogrants.org/proposals/nell_lucas_2022.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Fellowship in Biology
 discipline: evolutionary ecology
 status: funded

--- a/_grants/norman_kari_2016a.md
+++ b/_grants/norman_kari_2016a.md
@@ -4,7 +4,7 @@ title: A latent variable modeling approach to multi-taxa prediction
 author: Kari Norman
 year: 2016
 link: https://doi.org/10.6084/m9.figshare.5198731
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 status: funded
 ---

--- a/_grants/piwowar_heather_2013a.md
+++ b/_grants/piwowar_heather_2013a.md
@@ -4,7 +4,7 @@ title: Investigating the value of automatically-gathered software impact data
 author: Heather Piwowar and Jason Priem
 year: 2013
 link: https://doi.org/10.6084/m9.figshare.809572
-funder: National Science Foundation (NSF)
+funder: "U.S. National Science Foundation (NSF)"
 program: ACI-CYBERINFRASTRUCTURE, EAGER
 status: funded
 ---

--- a/_grants/reisinger_alexander_2022.md
+++ b/_grants/reisinger_alexander_2022.md
@@ -8,7 +8,7 @@ ORCID: 0000-0003-4096-2637
 year: '2022'
 institution: University of Florida
 link: https://www.ogrants.org/proposals/reisinger_alexander_2022.pdf
-funder: National Science Foundation
+funder: "U.S. National Science Foundation (NSF)"
 program: DISES
 discipline: interdisciplinary
 status: funded

--- a/_grants/rick_jessica_2021.md
+++ b/_grants/rick_jessica_2021.md
@@ -6,7 +6,7 @@ ORCID: 0000-0002-8927-220X
 year: 2021
 link: ["https://d33wubrfki0l68.cloudfront.net/6b5aa9f3-039d-47d5-97f5-f6579b53d8a2/Rick_NSF_Postdoc_Proposal.pdf"]
 link_name: ["Proposal"]
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Fellowship in Biology
 discipline: Evolutionary Biology
 status: funded

--- a/_grants/ross-ibarra_jeff_2015.md
+++ b/_grants/ross-ibarra_jeff_2015.md
@@ -4,7 +4,7 @@ title: The genetics of highland adaptation in maize
 author: Jeff Ross-Ibarra
 year: 2015
 link: https://github.com/RILAB/statements/blob/master/grants/Ross-Ibarra_NSF_PlantGenome_2015.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Plant Genome Research
 status: funded
 ---

--- a/_grants/seekell_d_2010.md
+++ b/_grants/seekell_d_2010.md
@@ -5,7 +5,7 @@ author: David Seekell
 ORCID: 0000-0001-6700-6149
 year: 2010
 link: https://doi.org/10.5281/zenodo.1303986
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: ecology
 status: funded

--- a/_grants/seekell_d_2011.md
+++ b/_grants/seekell_d_2011.md
@@ -5,7 +5,7 @@ author: David Seekell
 ORCID: 0000-0001-6700-6149
 year: 2011
 link: https://doi.org/10.5281/zenodo.1303998
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Nordic Research Opportunity
 discipline: ecology
 status: funded

--- a/_grants/shelton_delia_2010.md
+++ b/_grants/shelton_delia_2010.md
@@ -4,7 +4,7 @@ title: 'The Biological Constraints of Learning in Fathead Minnows (Pimphales pro
 author: Delia Shelton
 year: 2010
 link: https://docs.google.com/viewer?a=v&pid=sites&srcid=ZGVmYXVsdGRvbWFpbnxzaGVsdG9uZGVsaWF8Z3g6ZjkwZTNhOThhYWVhNjdm
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 status: funded
 ---

--- a/_grants/shelton_delia_2016.md
+++ b/_grants/shelton_delia_2016.md
@@ -4,7 +4,7 @@ title: Developing groups and their response to anthropogenic change
 author: Delia Shelton
 year: 2016
 link: https://doi.org/10.6084/m9.figshare.4263344
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Fellowship in Biology
 status: funded
 ---

--- a/_grants/supp_sarah_2014.md
+++ b/_grants/supp_sarah_2014.md
@@ -4,7 +4,7 @@ title: 'Dynamic macroecology: Globally assessing body size diversity response to
 author: Sarah Supp
 year: 2014
 link: https://doi.org/10.6084/m9.figshare.1137190
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Fellowship in Biology
 status: funded
 ---

--- a/_grants/teitelbaum_clair_2016.md
+++ b/_grants/teitelbaum_clair_2016.md
@@ -5,7 +5,7 @@ author: Claire S. Teitelbaum
 ORCID: 
 year: 2016
 link: https://353a23c500dde3b2ad58-c49fe7e7355d384845270f4a7a0a7aa1.ssl.cf2.rackcdn.com/4823cf41-e8f2-40f5-950e-b0223c3f845a/Teitelbaum_research.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: ecology
 status: funded

--- a/_grants/treddenick_andrew_2014.md
+++ b/_grants/treddenick_andrew_2014.md
@@ -5,7 +5,7 @@ author: Andrew Tredennick
 ORCID: 0000-0003-1254-3339
 year: 2014
 link: https://doi.org/10.6084/m9.figshare.4981529.v1
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Fellowship in Biology
 status: funded
 ---

--- a/_grants/vision_todd_2008.md
+++ b/_grants/vision_todd_2008.md
@@ -4,6 +4,6 @@ title: A Digital Repository for Preservation and Sharing of Data Underlying Publ
 author: Todd Vision
 year: 2008
 link: http://wiki.datadryad.org/images/9/96/Dryad.proj.descr.07.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 status: funded
 ---

--- a/_grants/vision_todd_2012.md
+++ b/_grants/vision_todd_2012.md
@@ -4,6 +4,6 @@ title: Sustainable and Scalable Infrastructure for the Publication of Data
 author: Todd Vision
 year: 2012
 link: http://wiki.datadryad.org/images/e/ec/Dryad_abi11_short.pdf
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 status: funded
 ---

--- a/_grants/white_2005.md
+++ b/_grants/white_2005.md
@@ -5,7 +5,7 @@ author: Ethan P. White
 ORCID: 0000-0001-6728-7745
 year: 2005
 link: https://doi.org/10.6084/m9.figshare.93938
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Fellowship in Biology
 discipline: ecology
 status: funded

--- a/_grants/white_2008.md
+++ b/_grants/white_2008.md
@@ -5,7 +5,7 @@ author: Ethan P. White
 ORCID: 0000-0001-6728-7745
 year: 2008
 link: https://doi.org/10.6084/m9.figshare.93939
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Research Starter Grant
 discipline: ecology
 status: funded

--- a/_grants/white_2010.md
+++ b/_grants/white_2010.md
@@ -5,7 +5,7 @@ author: Ethan P. White
 ORCID: 0000-0001-6728-7745
 year: 2010
 link: https://doi.org/10.6084/m9.figshare.93937
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: CAREER
 discipline: ecology
 status: funded

--- a/_grants/wright_april_2013.md
+++ b/_grants/wright_april_2013.md
@@ -5,7 +5,7 @@ author: April M. Wright
 ORCID: 0000-0003-4692-3225
 year: 2013
 link: https://figshare.com/articles/Wright_Funded_DDIG_2013/5234758
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Doctoral Dissertation Improvement Grant
 discipline: Evolution
 status: funded

--- a/_grants/wright_april_2016.md
+++ b/_grants/wright_april_2016.md
@@ -5,7 +5,7 @@ author: April M. Wright
 ORCID: 0000-0003-4692-3225
 year: 2016
 link: https://figshare.com/articles/NSF_Postdoc_Project_Desc_/3119680
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Postdoctoral Fellowship in Biology
 discipline: Evolution
 status: funded

--- a/_grants/wright_april_2020.md
+++ b/_grants/wright_april_2020.md
@@ -6,7 +6,7 @@ ORCID: 0000-0003-4692-3225
 year: 2020
 link: ["https://doi.org/10.5281/zenodo.4323127"]
 link_name: [Proposal]
-funder: "National Science Foundation"
+funder: "U.S. National Science Foundation (NSF)"
 program: "CAREER"
 discipline: evolution, paleobiology
 status: funded

--- a/_grants/yoder_jeremy_2008.md
+++ b/_grants/yoder_jeremy_2008.md
@@ -5,7 +5,7 @@ author: Jeremy B. Yoder
 ORCID: 0000-0002-5630-0921
 year: 2008
 link: https://doi.org/10.6084/m9.figshare.5412853.v1
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Doctoral Dissertation Improvement Grant
 discipline: evolutionary biology
 status: funded

--- a/_grants/zare_alina_2013.md
+++ b/_grants/zare_alina_2013.md
@@ -6,7 +6,7 @@ ORCID: "0000-0002-4847-7604"
 year: 2013
 link: ["https://d33wubrfki0l68.cloudfront.net/dcf2f802-e88a-4907-8297-e1a9391a08ac/2013_07_22_ZareNSFCAREER.pdf"]
 link_name: ["Proposal"]
-funder: "NSF"
+funder: "U.S. National Science Foundation (NSF)"
 program: "CAREER"
 discipline: "Computer Science"
 status: funded

--- a/_grants/zorowitz_sam_2018.md
+++ b/_grants/zorowitz_sam_2018.md
@@ -6,7 +6,7 @@ ORCID: 0000-0001-8073-1257
 year: 2018
 link: ['https://github.com/szorowi1/szorowi1.github.io/blob/master/assets/documents/grfp/szoro_nsf_grfp_research_proposal_FINAL.pdf', 'https://github.com/szorowi1/szorowi1.github.io/blob/master/assets/documents/grfp/szoro_nsf_grfp_personal_statement_FINAL.pdf', 'https://github.com/szorowi1/szorowi1.github.io/blob/master/assets/documents/grfp/szoro_nsf_grfp_reviews.pdf']
 link_name: ['Research Statement', 'Personal Statement', 'Reviews']
-funder: NSF
+funder: "U.S. National Science Foundation (NSF)"
 program: Graduate Research Fellowship Program
 discipline: Cognitive Neuroscience
 status: funded


### PR DESCRIPTION
There were several versions of NSF in the metadata. This updates to a full name to disambiguate from National Science Foundations in other countries, but includes the NSF abbreviation parenthetically.